### PR TITLE
Admin and collaborators

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,8 @@ class ApplicationController < ActionController::Base
   def check_user
     redirect_to root_path, alert: "Not Authorized" if current_user.nil?
   end
+
+  def is_admin?
+    redirect_to root_path, alert: "Not Authorized" unless current_user.admin
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: "Not Authorized" if current_user.nil?
   end
 
-  def is_admin?
+  def admin?
     redirect_to root_path, alert: "Not Authorized" unless current_user.admin
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post,  only: [:show,  :edit, :update, :destroy]
-  before_action :check_user
+  before_action :check_user, except: [:show]
 
   respond_to :html
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,11 @@
 class UsersController < ApplicationController
   before_action :check_user
-  before_action :is_admin?
+  before_action :admin?
 
   respond_to :html
 
-	def index
+  def index
     @users = User.paginate(page: params[:user], per_page: 10)
     respond_with @users
-	end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+class UsersController < ApplicationController
+  before_action :check_user
+  before_action :is_admin?
+
+  respond_to :html
+
+	def index
+    @users = User.paginate(page: params[:user], per_page: 10)
+    respond_with @users
+	end
+end

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -12,7 +12,7 @@
       %tr
         %td= category.description
         %td= link_to "Edit", edit_category_path(category)
-        %td= link_to "Delete", category, :method => :delete, :data => { :confirm => "Are you sure?" }
+        %td= link_to "Delete", category, :method => :delete, :data => { :confirm => "Are you sure?" } if current_user.admin
 
 %br
 

--- a/app/views/layouts/_navigation_links.html.haml
+++ b/app/views/layouts/_navigation_links.html.haml
@@ -4,9 +4,6 @@
   %a{href: about_index_path } About Us
 %li.nav-link
   %a{href: contact_index_path } Contact
-- if !signed_in?
-  %li.nav-link
-    %a{href: sign_in_path } Sign In
 - if signed_in?
   %li.nav-link.more
     %a{:href => "#"} Admin

--- a/app/views/layouts/_navigation_links.html.haml
+++ b/app/views/layouts/_navigation_links.html.haml
@@ -12,7 +12,8 @@
         %a{:href => posts_path} Blogs Entries
       %li
         %a{:href => categories_path} Categories
-      %li
-        %a{:href => "#"} Contributors
+      - if current_user.admin?
+        %li
+          %a{:href => users_path} Contributors
       %li
         %a{:href => log_out_path} Sign Out

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,22 @@
+%h1 Listing Users
+
+%table.tables
+  %thead
+    %tr
+      %th Email
+      %th Admin?
+      %th
+      %th
+
+  %tbody
+    - @users.each do |user|
+      %tr
+        %td= user.email
+        %td= user.admin
+        %td= link_to "Edit", edit_user_path(user)
+        %td= link_to "Delete", user, :method => :delete, :data => { :confirm => "Are you sure?" }
+= will_paginate @users
+
+%br
+
+= link_to "New User", new_user_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   mount Ckeditor::Engine => "/ckeditor"
   resources :posts
   resources :categories
+  resources :users
 	resources :home,    only: :index
 	resources :contact, only: :index
   resources :about,   only: :index

--- a/lib/tasks/development_seed.rake
+++ b/lib/tasks/development_seed.rake
@@ -10,8 +10,8 @@ unless Rails.env.production?
 
       ## Create Users
       create(:user)
-      create(:collab_user_one)
-      create(:collab_user_two)
+      create(:contributor_one)
+      create(:contributor_two)
 
       ## Create Categories
       create(:programming)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,15 +2,18 @@ FactoryGirl.define do
   factory :user do
     email "user@example.com"
     password "theMaindud3"
+    admin true
 
     factory :collab_user_one do
       email "jack@example.com"
       password "Buck3t99"
+      admin false
     end
 
     factory :collab_user_two do
       email "jill@example.com"
       password "ic3dWater"
+      admin false
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,13 +4,13 @@ FactoryGirl.define do
     password "theMaindud3"
     admin true
 
-    factory :collab_user_one do
+    factory :contributor_one do
       email "jack@example.com"
       password "Buck3t99"
       admin false
     end
 
-    factory :collab_user_two do
+    factory :contributor_two do
       email "jill@example.com"
       password "ic3dWater"
       admin false

--- a/spec/features/user/categories_spec.rb
+++ b/spec/features/user/categories_spec.rb
@@ -4,7 +4,7 @@ feature "Managing Categories" do
 
   given(:user)         { create :user }
   given(:category)     { create :category }
-  given(:collaborator) { create :collab_user_one }
+  given(:contrib_one)  { create :contributor_one }
 
   scenario "Visit Category page" do
     sign_in(user)
@@ -46,7 +46,7 @@ feature "Managing Categories" do
   end
 
   scenario "Collaborator not able to delete a category" do
-    sign_in(collaborator)
+    sign_in(contrib_one)
     create(:category)
 
     visit categories_path

--- a/spec/features/user/categories_spec.rb
+++ b/spec/features/user/categories_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 feature "Managing Categories" do
 
-  given(:user)     { create :user }
-  given(:category) { create :category }
+  given(:user)         { create :user }
+  given(:category)     { create :category }
+  given(:collaborator) { create :collab_user_one }
 
   scenario "Visit Category page" do
     sign_in(user)
@@ -42,5 +43,14 @@ feature "Managing Categories" do
     click_link "Delete"
 
     expect(page).to have_content "Successfully deleted"
+  end
+
+  scenario "Collaborator not able to delete a category" do
+    sign_in(collaborator)
+    create(:category)
+
+    visit categories_path
+
+    expect(page).to_not have_link "Delete"
   end
 end

--- a/spec/features/user/contributor_admin_spec.rb
+++ b/spec/features/user/contributor_admin_spec.rb
@@ -38,18 +38,17 @@ feature "Managing user resource" do
     expect(page).to have_content "Not Authorized"
   end
 
-#  scenario "A non-admin should not be able to edit a user admin resource directly." do
-#    user
-#    sign_in(contrib_two)
-#
-#    visit "/users/1/edit"
-#
-#    expect(page).to have_content "Not Authorized"
-#  end
+  # scenario "A non-admin should not be able to edit a user admin resource directly." do
+  #   user
+  #   sign_in(contrib_two)
+
+  #   visit "/users/1/edit"
+
+  #   expect(page).to have_content "Not Authorized"
+  # end
 
   scenario "A visitor should not be able to access user admin resource directly. " do
     visit "/users"
     expect(page).to have_content "Not Authorized"
   end
 end
-

--- a/spec/features/user/contributor_admin_spec.rb
+++ b/spec/features/user/contributor_admin_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+feature "Managing user resource" do
+
+  given(:user)       { create :user }
+  given(:contrib_one) { create :contributor_one }
+  given(:contrib_two) { create :contributor_two }
+
+  scenario "Admin can list all registered users" do
+    contrib_one
+    contrib_two
+
+    sign_in(user)
+    visit root_path
+    click_link "Admin"
+    click_link "Contributors"
+
+    expect(page).to have_content "Listing Users"
+    expect(page).to have_content "user@example.com"
+    expect(page).to have_content "jack@example.com"
+    expect(page).to have_content "jill@example.com"
+  end
+
+  scenario "A non-admin should not be able to access user admin resource." do
+    sign_in(contrib_one)
+
+    visit root_path
+    click_link "Admin"
+
+    expect(page).to_not have_link "Contributors"
+  end
+
+  scenario "A non-admin should not be able to access user admin resource directly." do
+    sign_in(contrib_one)
+
+    visit "/users"
+
+    expect(page).to have_content "Not Authorized"
+  end
+
+#  scenario "A non-admin should not be able to edit a user admin resource directly." do
+#    user
+#    sign_in(contrib_two)
+#
+#    visit "/users/1/edit"
+#
+#    expect(page).to have_content "Not Authorized"
+#  end
+
+  scenario "A visitor should not be able to access user admin resource directly. " do
+    visit "/users"
+    expect(page).to have_content "Not Authorized"
+  end
+end
+

--- a/spec/features/user/login_spec.rb
+++ b/spec/features/user/login_spec.rb
@@ -1,19 +1,19 @@
 require "rails_helper"
 
-feature "User logs into site" do
+	feature "User logs into site" do
 
-	given(:user) { create :user }
+		given(:user) { create :user }
 
-	scenario "user logs in" do
-		sign_in(user)
+		scenario "user logs in" do
+			sign_in(user)
 
-		expect(page).to have_link "Admin"
-	end
+			expect(page).to have_link "Admin"
+		end
 
-	scenario "user logs out" do
-		sign_in(user)
-		sign_out
+		scenario "user logs out" do
+			sign_in(user)
+			sign_out
 
-		expect(page).to_not have_link "Admin"
-	end
+			expect(page).to_not have_link "Admin"
+		end
 end

--- a/spec/features/user/login_spec.rb
+++ b/spec/features/user/login_spec.rb
@@ -14,6 +14,6 @@ feature "User logs into site" do
 		sign_in(user)
 		sign_out
 
-		expect(page).to have_link "Sign In"
+		expect(page).to_not have_link "Admin"
 	end
 end

--- a/spec/features/visitor/home_spec.rb
+++ b/spec/features/visitor/home_spec.rb
@@ -12,4 +12,19 @@ feature "Viewing Home Page" do
 
     expect(page).to_not have_link "Admin"
   end
+
+  scenario "a visitor should not see a sign in link" do
+    visit root_path
+
+    expect(page).to_not have_link "Sign In"
+  end
+
+  scenario "a visitor clicks link for a blog entry to see more" do
+    create(:ssh)
+    visit root_path
+    click_link "Passwordless login with ssh"
+
+    expect(page).to_not have_content "Not Authorized"
+    expect(page).to have_content "To be able to login to your remote over ssh"
+  end
 end


### PR DESCRIPTION
Refactored and renamed factories, tests, and rake task changing collaborator to contributor.  Framed out the user admin resource and restricted its access to admins only.  Contributors and visitors should NOT have access to the resource.