### PR TITLE
Admins not deletable

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :check_user
   before_action :admin?
-  before_action :set_user, only: [:edit, :update]
+  before_action :set_user, only: [:edit, :update, :destroy]
 
   respond_to :html
 
@@ -26,6 +26,11 @@ class UsersController < ApplicationController
   def update
     flash[:success] = "Update successfull!" if @user.update(user_params)
     redirect_to users_path
+  end
+
+  def destroy
+    @user.destroy
+    redirect_to users_path, alert: "Contributor removed successfully."
   end
 
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,7 +14,10 @@
         %td= user.email
         %td= user.admin
         %td= link_to "Edit", edit_user_path(user)
-        %td= link_to "Delete", user, :method => :delete, :data => { :confirm => "Are you sure?" }
+        - if user.admin?
+          %td 
+        - else
+          %td= link_to "Delete", user, :method => :delete, :data => { :confirm => "Are you sure?" }
 = will_paginate @users
 
 %br

--- a/spec/features/user/contributor_admin_spec.rb
+++ b/spec/features/user/contributor_admin_spec.rb
@@ -35,7 +35,7 @@ feature "Managing user resource" do
 
     manage_contributor
 
-    find(:xpath, "//tr[contains(.,'jack')]/td/a", :text => "Edit").click
+    find(:xpath, "//tr[contains(.,'jack')]/td/a", text: "Edit").click
     check("Admin")
     click_button "Update User"
 
@@ -48,7 +48,7 @@ feature "Managing user resource" do
 
     manage_contributor
 
-    find(:xpath, "//tr[contains(.,'jack')]/td/a", :text => "Edit").click
+    find(:xpath, "//tr[contains(.,'jack')]/td/a", text: "Edit").click
     fill_in "Password", with: "nopwdReqd"
     click_button "Update User"
 
@@ -62,7 +62,7 @@ feature "Managing user resource" do
     contrib_one
 
     manage_contributor
-    find(:xpath, "//tr[contains(.,'jack')]/td/a", :text => "Delete").click
+    find(:xpath, "//tr[contains(.,'jack')]/td/a", text: "Delete").click
 
     expect(page).to have_content "Contributor removed successfully."
   end

--- a/spec/features/user/contributor_admin_spec.rb
+++ b/spec/features/user/contributor_admin_spec.rb
@@ -58,7 +58,16 @@ feature "Managing user resource" do
     sign_in_user_with_password_changed
   end
 
-  scenario "Users that are admin true should not display delete link", focus: true do
+  scenario "Admin can delete a contributor." do
+    contrib_one
+
+    manage_contributor
+    find(:xpath, "//tr[contains(.,'jack')]/td/a", :text => "Delete").click
+
+    expect(page).to have_content "Contributor removed successfully."
+  end
+
+  scenario "Users that are admin true should not display delete link" do
     contrib_one
     contrib_two
 

--- a/spec/features/user/contributor_admin_spec.rb
+++ b/spec/features/user/contributor_admin_spec.rb
@@ -58,6 +58,16 @@ feature "Managing user resource" do
     sign_in_user_with_password_changed
   end
 
+  scenario "Users that are admin true should not display delete link", focus: true do
+    contrib_one
+    contrib_two
+
+    manage_contributor
+
+    expect(page).to have_xpath("//tr[contains(.,'jack')][contains(.,'Delete')]")
+    expect(page).to_not have_xpath("//tr[contains(.,'user')][contains(.,'Delete')]")
+  end
+
   scenario "A non-admin should not be able to access user admin resource." do
     sign_in(contrib_one)
 


### PR DESCRIPTION
Completed feature so that users that are classified as admins cannot be deleted.  Also ensured that normal contributors can be deleted.