### PR TITLE
Post redirect test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,3 @@ Users
 * Add Footer (DL)
 * Fix Failing Category test (DL)
 * Add Test for User Sign In/Out (DL)
-* Add Categories to Posts (Josh)
-* Add controller test for post redirect (Josh)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,7 +17,6 @@ class PostsController < ApplicationController
   def show
     @post = Post.friendly.find(params[:id])
     set_post_redirect
-    respond_with @post
   end
 
   def edit

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PostsController, type: :controller do
 
@@ -6,8 +6,8 @@ RSpec.describe PostsController, type: :controller do
 
     before :each do
       @post = FactoryGirl.create(:post)
-      @old_slug = @post.slug 
-      @post.update(title: 'Darkhorse post')
+      @old_slug = @post.slug
+      @post.update(title: "Darkhorse post")
       @new_slug = @post.slug
     end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe PostsController, type: :controller do
+
+  describe "GET #show" do
+
+    before :each do
+      @post = FactoryGirl.create(:post)
+      @old_slug = @post.slug 
+      @post.update(title: 'Darkhorse post')
+      @new_slug = @post.slug
+    end
+
+    it "redirects old slug to new slug" do
+      get :show, id: @old_slug
+      new_location = post_path(@new_slug)
+      expect(response).to redirect_to(new_location)
+    end
+  end
+end


### PR DESCRIPTION
When viewing a post from an old slug URL, the posts controller redirects to the most current slugged URL.

This allows links from external sites with old slug URLs to redirect to the new slug, instead of throwing a 404.